### PR TITLE
flush output to improve wake up reason timestamps

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -209,6 +209,7 @@ int parse_arp(unsigned char *data) {
 				printf("Magic packet sent by '");
 				print_ip(src_ip);
 				puts("'");
+				fflush(stdout); //Write now to get an accurate timestamp for analyzing wake-up reason
 			}
 		}
 	}


### PR DESCRIPTION
The stdout buffer is ridiculous large on raspberry OS.
I don't know if this is a normal size or if it is SD card access tuning. But it doesn't matter, without the flush the logging is useless.