### PR TITLE
Fix ignore Gateway wakeup

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -221,7 +221,7 @@ int parse_arp(unsigned char *data) {
 							puts("Blocked ARP wake-up by gateway");
 							fflush(stdout);
 						#endif
-						return 0;
+						break;
 					}
 				}
 				RETONFAIL(send_magic_packet(link->magic));

--- a/src/main.c
+++ b/src/main.c
@@ -221,6 +221,7 @@ int parse_arp(unsigned char *data) {
 							puts("Blocked ARP wake-up by gateway");
 							fflush(stdout);
 						#endif
+						return 0;
 					}
 				}
 				RETONFAIL(send_magic_packet(link->magic));


### PR DESCRIPTION
Day before yesterday I did some allow gateway = true tests.
Today I was a bit confused why gateway wake-ups are still allowed, and weird log outputs did tell that something is wrong.

I would say, don't trust @Falcosc he tries to sabotage your project. Just look at the metrics, he is flooding your repo with commits to obfuscate something in your code.