### PR TITLE
Fix endianess of subnet mask

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -17,6 +17,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <signal.h>
+#include <byteswap.h>
 
 #include "ns_arp.h"
 #include "ns_arp_packet.h"
@@ -309,7 +310,8 @@ int parse_args() {
 		}
 
 		// calculate proper net mask
-		m.subnet = 0xffffffff >> (32-mask_value);  
+		unsigned int subnet_bigendian = 0xffffffff << (32-mask_value);
+		m.subnet = __bswap_32(subnet_bigendian);
 	}
 
 	// should we allow gateway ARP requests


### PR DESCRIPTION
Subnetmask 25 did not work because
00000001 11111111 11111111 11111111 is not the correct little endian representation of 25
It should be
10000000 11111111 11111111 11111111