### PR TITLE
feat: add source allowlist/blocklist with hostname support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,10 @@
+name: Build and Release
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
   build-armv7:
     name: Build Linux ARMv7 (32-bit)
     runs-on: ubuntu-24.04-arm
@@ -16,13 +23,6 @@
           name: wake-on-arp-linux-armv7
           path: wake-on-arp-linux-armv7
 
-name: Build and Release
-
-on:
-  push:
-    branches: [ master ]
-
-jobs:
   build-x64:
     name: Build Linux x64
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           path: wake-on-arp-linux-arm64
 
   release:
-    needs: [build-x64, build-arm64]
+    needs: [build-x64, build-arm64, build-armv7]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+
 name: Build and Release
 
 on:
@@ -5,53 +6,40 @@ on:
     branches: [ master ]
 
 jobs:
-  build-linux:
-    name: Build Linux Binaries
+  build-x64:
+    name: Build Linux x64
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - arch: x86_64
-            cc: gcc
-            exe: wake-on-arp-linux-x64
-          - arch: aarch64
-            cc: aarch64-linux-gnu-gcc
-            exe: wake-on-arp-linux-arm64
     steps:
       - uses: actions/checkout@v4
-      - name: Install cross compilers
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
       - name: Build
         run: |
           make clean
-          make wake-on-arp CC=${{ matrix.cc }}
-          mv wake-on-arp ${{ matrix.exe }}
+          make wake-on-arp
+          mv wake-on-arp wake-on-arp-linux-x64
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.exe }}
-          path: ${{ matrix.exe }}
+          name: wake-on-arp-linux-x64
+          path: wake-on-arp-linux-x64
 
-  # Optionally, add macOS build (experimental, may require code tweaks)
-  # build-macos:
-  #   runs-on: macos-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Build
-  #       run: |
-  #         make clean
-  #         make wake-on-arp
-  #         mv wake-on-arp wake-on-arp-macos
-  #     - name: Upload artifact
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: wake-on-arp-macos
-  #         path: wake-on-arp-macos
+  build-arm64:
+    name: Build Linux ARM64
+    runs-on: ARM64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: |
+          make clean
+          make wake-on-arp
+          mv wake-on-arp wake-on-arp-linux-arm64
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wake-on-arp-linux-arm64
+          path: wake-on-arp-linux-arm64
 
   release:
-    needs: build-linux
+    needs: [build-x64, build-arm64]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Build and Release
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build-linux:
+    name: Build Linux Binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            cc: gcc
+            exe: wake-on-arp-linux-x64
+          - arch: aarch64
+            cc: aarch64-linux-gnu-gcc
+            exe: wake-on-arp-linux-arm64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cross compilers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+      - name: Build
+        run: |
+          make clean
+          make wake-on-arp CC=${{ matrix.cc }}
+          mv wake-on-arp ${{ matrix.exe }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.exe }}
+          path: ${{ matrix.exe }}
+
+  # Optionally, add macOS build (experimental, may require code tweaks)
+  # build-macos:
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Build
+  #       run: |
+  #         make clean
+  #         make wake-on-arp
+  #         mv wake-on-arp wake-on-arp-macos
+  #     - name: Upload artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: wake-on-arp-macos
+  #         path: wake-on-arp-macos
+
+  release:
+    needs: build-linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+      - name: Display artifacts
+        run: ls -lR ./artifacts
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: nightly-${{ github.sha }}
+          name: Nightly build ${{ github.sha }}
+          draft: false
+          prerelease: true
+          files: ./artifacts/**/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: nightly-${{ github.sha }}
-          name: Nightly build ${{ github.sha }}
+          tag_name: nightly-${{ github.run_id }}
+          name: Nightly build ${{ github.run_id }}
           draft: false
           prerelease: true
           files: ./artifacts/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,20 @@
+  build-armv7:
+    name: Build Linux ARMv7 (32-bit)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cross compiler
+        run: sudo apt-get update && sudo apt-get install -y gcc-arm-linux-gnueabihf
+      - name: Build
+        run: |
+          make clean
+          make wake-on-arp CC=arm-linux-gnueabihf-gcc
+          mv wake-on-arp wake-on-arp-linux-armv7
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wake-on-arp-linux-armv7
+          path: wake-on-arp-linux-armv7
 
 name: Build and Release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,29 @@ jobs:
           name: wake-on-arp-linux-armv7
           path: wake-on-arp-linux-armv7
 
+  build-armv7-raspbian-bullseye:
+    name: Build Linux ARMv7 (Raspbian Bullseye)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build in Bullseye Docker
+        uses: addnab/docker-run-action@v3
+        with:
+          image: debian:bullseye
+          options: -v ${{ github.workspace }}:/workspace
+          run: |
+            apt-get update
+            apt-get install -y build-essential gcc-arm-linux-gnueabihf make
+            cd /workspace
+            make clean
+            make wake-on-arp CC=arm-linux-gnueabihf-gcc
+            mv wake-on-arp wake-on-arp-linux-armv7-raspbian-bullseye
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wake-on-arp-linux-armv7-raspbian-bullseye
+          path: wake-on-arp-linux-armv7-raspbian-bullseye
+
   build-x64:
     name: Build Linux x64
     runs-on: ubuntu-latest
@@ -56,7 +79,7 @@ jobs:
           path: wake-on-arp-linux-arm64
 
   release:
-    needs: [build-x64, build-arm64, build-armv7]
+    needs: [build-x64, build-arm64, build-armv7, build-armv7-raspbian-bullseye]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
   build-arm64:
     name: Build Linux ARM64
-    runs-on: ARM64
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - name: Build

--- a/example.conf
+++ b/example.conf
@@ -14,6 +14,16 @@ subnet        24
 # Allow the gateway (your router) to send ARP requests, stops misbehaving routers
 allow_gateway false
 
-# Ignores ARP requests from this IP (you can add as many of these as you like)
+
+# Ignores ARP requests from this IP or hostname (can add multiple)
 source_exclude 192.168.1.5
+# source_exclude my-blocked-host.local
+
+# Only allow ARP requests from these IPs or hostnames (can add multiple)
+# If set, only these sources are allowed (unless also in exclude list)
+# source_include 192.168.1.10
+# source_include my-allowed-host.local
+
+# Optional: DNS cache refresh interval in seconds (default: 300)
+# dns_cache_refresh_interval 300
 

--- a/include/ns_config.h
+++ b/include/ns_config.h
@@ -1,3 +1,6 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <time.h>
 /*
  * The MIT License (MIT)
  *
@@ -47,5 +50,25 @@
 #define IN																	const
 #define OUT
 #define INOUT
+
+// DNS cache refresh interval in seconds
+#define DEFAULT_DNS_CACHE_REFRESH_INTERVAL  300
+
+// Maximum number of entries in allow/exclude lists
+#define MAX_SOURCE_LIST_ENTRIES 64
+
+// Structure for a source entry (IP or hostname)
+typedef struct {
+	char *entry; // IP string or hostname
+	uint32_t ip; // resolved IP (if available)
+	bool is_hostname;
+} source_entry_t;
+
+// DNS cache for hostnames in allow/exclude lists
+typedef struct {
+	source_entry_t entries[MAX_SOURCE_LIST_ENTRIES];
+	size_t count;
+	time_t last_refresh;
+} dns_cache_t;
 
 #endif /* NS_CONFIG_H_ */

--- a/src/main.c
+++ b/src/main.c
@@ -80,21 +80,6 @@ int resolve_hostname(const char *hostname, uint32_t *out_ip) {
 }
 
 // Non-blocking DNS cache refresh (only refresh if really needed and been a while)
-void refresh_dns_cache_if_needed_nonblocking(dns_cache_t *cache) {
-	if (!cache) return;
-	
-	static time_t last_any_refresh = 0;
-	time_t now = time(NULL);
-	
-	// Only refresh if it's been at least the full interval since ANY refresh
-	if (last_any_refresh != 0 && (now - last_any_refresh) < DEFAULT_DNS_CACHE_REFRESH_INTERVAL) {
-		return; // Not time yet, skip to avoid blocking
-	}
-	
-	// Do the refresh (this might take time but only happens every 5 minutes)
-	refresh_dns_cache_if_needed(cache);
-	last_any_refresh = now;
-}
 void refresh_dns_cache_if_needed(dns_cache_t *cache) {
 	if (!cache) return;
 	
@@ -136,6 +121,23 @@ void refresh_dns_cache_if_needed(dns_cache_t *cache) {
 		}
 		cache->last_refresh = now;
 	}
+}
+
+// Non-blocking DNS cache refresh (only refresh if really needed and been a while)
+void refresh_dns_cache_if_needed_nonblocking(dns_cache_t *cache) {
+	if (!cache) return;
+	
+	static time_t last_any_refresh = 0;
+	time_t now = time(NULL);
+	
+	// Only refresh if it's been at least the full interval since ANY refresh
+	if (last_any_refresh != 0 && (now - last_any_refresh) < DEFAULT_DNS_CACHE_REFRESH_INTERVAL) {
+		return; // Not time yet, skip to avoid blocking
+	}
+	
+	// Do the refresh (this might take time but only happens every 5 minutes)
+	refresh_dns_cache_if_needed(cache);
+	last_any_refresh = now;
 }
 
 #ifndef CONFIG_PREFIX

--- a/src/main.c
+++ b/src/main.c
@@ -410,7 +410,10 @@ int load_config() {
 	FILE *fp = fopen(CONFIG_PREFIX"/wake-on-arp.conf", "r");
 	if(!fp) {
 		fprintf(stderr, "Could not open config file: "CONFIG_PREFIX"/wake-on-arp.conf\n");
-		return 1;
+		// Still initialize arrays to avoid segfaults
+		arr_init(m.source_blacklist);
+		arr_init(m.target_list);
+		return 0; // Not an error, just skip config loading
 	}
 
 	// init variables

--- a/src/targets.c
+++ b/src/targets.c
@@ -43,11 +43,11 @@ int targets_configure(struct target *list) {
 
 		struct target *ta = &list[i];
 		if(ta->mac_s == NULL) {
-			fprintf(stderr, "Missing element 'target_mac_%lu'\n", i);
+			fprintf(stderr, "Missing element 'target_mac_%zu'\n", i);
 			return 1;
 		}
 		if(ta->ip_s == NULL) {
-			fprintf(stderr, "Missing element 'target_ip_%lu'\n", i);
+			fprintf(stderr, "Missing element 'target_ip_%zu'\n", i);
 			return 1;
 		}
 
@@ -60,7 +60,7 @@ int targets_configure(struct target *list) {
 				&ta->mac[0], &ta->mac[1], &ta->mac[2], &ta->mac[3], &ta->mac[4], &ta->mac[5]);
 		}
 		if(error != 6) {
-			fprintf(stderr, "Invalid 'ta_mac_%lu' address: \"%s\"\n", i, ta->mac_s);
+			fprintf(stderr, "Invalid 'ta_mac_%zu' address: \"%s\"\n", i, ta->mac_s);
 			return 2;
 		}
 
@@ -68,7 +68,7 @@ int targets_configure(struct target *list) {
 		error = sscanf(ta->ip_s, "%hhu.%hhu.%hhu.%hhu", &ta->ip[0],
 									&ta->ip[1], &ta->ip[2], &ta->ip[3]);
 		if(error != 4) {
-			fprintf(stderr, "Invalid 'ta_ip_%lu' address: \"%s\"\n", i, ta->ip_s);
+			fprintf(stderr, "Invalid 'ta_ip_%zu' address: \"%s\"\n", i, ta->ip_s);
 			return 2;
 		}
 


### PR DESCRIPTION
# Add source allowlist/blocklist with hostname support

## Summary
Adds `source_include` (allowlist) and enhanced `source_exclude` (blocklist) functionality with hostname resolution and DNS caching.

## Features
- **🎯 Allowlist**: `source_include` - only specified sources can trigger wake-up
- **🚫 Enhanced blocklist**: `source_exclude` - now supports hostnames  
- **🌐 Hostname support**: Both lists accept IP addresses or hostnames
- **⚡ DNS caching**: Hostnames resolved periodically (default: 5min) to avoid lookup delays
- **🐛 Runtime debug**: `--debug` flag for verbose logging

## Configuration
```properties
# Only allow these sources (optional - if unset, all sources allowed except excludes)
source_include 192.168.1.10
source_include my-laptop.local

# Block these sources (works with or without allowlist)
source_exclude 192.168.1.1  
source_exclude noisy-device.local
```

## Example Output
```
Listen for ARP requests from Source IPs 10.0.42.0 - 10.0.42.255
Allowlist (only these sources will trigger wake-up): my-laptop.local(10.0.42.10) 10.0.42.50
Blocklist (these sources will be ignored): noisy-device.local(10.0.42.5) 10.0.42.1
```

Also adds CI-generated build artifacts for a few platforms, and fixes a bug where the app crashes if a config file isn't present. 